### PR TITLE
Removing status sub resource from the chaosengine CRD

### DIFF
--- a/charts/litmus/templates/chaosengine_crd.yaml
+++ b/charts/litmus/templates/chaosengine_crd.yaml
@@ -18,7 +18,6 @@ spec:
     singular: chaosengine
   scope: Namespaced
   subresources:
-    status: {}
   validation:
     openAPIV3Schema:
       properties:


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Removing status sub resource from the chaosengine CRD