### PR TITLE
updated envs for litmus-operator-ci yaml

### DIFF
--- a/docs/litmus-operator-ci.yaml
+++ b/docs/litmus-operator-ci.yaml
@@ -62,6 +62,10 @@ spec:
           - chaos-operator
           imagePullPolicy: Always
           env:
+            #- name: CHAOS_RUNNER_IMAGE
+            #  value: "litmuschaos/ansible-runner:ci"
+            #- name: CHAOS_MONITOR_IMAGE
+            #  value: "litmuschaos/chaos-exporter:ci"
             - name: WATCH_NAMESPACE
               value: 
             - name: POD_NAME

--- a/docs/litmus-operator-ci.yaml
+++ b/docs/litmus-operator-ci.yaml
@@ -62,10 +62,10 @@ spec:
           - chaos-operator
           imagePullPolicy: Always
           env:
-            #- name: CHAOS_RUNNER_IMAGE
-            #  value: "litmuschaos/ansible-runner:ci"
-            #- name: CHAOS_MONITOR_IMAGE
-            #  value: "litmuschaos/chaos-exporter:ci"
+            - name: CHAOS_RUNNER_IMAGE
+              value: "litmuschaos/ansible-runner:ci"
+            - name: CHAOS_MONITOR_IMAGE
+              value: "litmuschaos/chaos-exporter:ci"
             - name: WATCH_NAMESPACE
               value: 
             - name: POD_NAME


### PR DESCRIPTION
Ensuring the chaos-runner and chaos-monitor are brought up with ci tags when deploying ci builds of operator.
Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>