### PR TITLE
(feat): Adding minimal permissions for chaos-operator

### DIFF
--- a/charts/litmus/templates/clusterrole.yaml
+++ b/charts/litmus/templates/clusterrole.yaml
@@ -9,6 +9,6 @@ metadata:
     instance: {{ .Release.Name  }}
     chart: {{ include "litmus.chart" . }}
 rules:
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
+- apiGroups: ["","apps","batch","litmuschaos.io"]
+  resources: ["pods","jobs","deployments","daemonsets","statefulsets","events","configmaps","services","chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["get","create","update","patch","delete","list","watch","deletecollection"]

--- a/docs/litmus-operator-ci.yaml
+++ b/docs/litmus-operator-ci.yaml
@@ -19,9 +19,9 @@ metadata:
   labels:
     name: litmus
 rules:
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
+- apiGroups: ["","apps","batch","litmuschaos.io"]
+  resources: ["pods","jobs","deployments","daemonsets","statefulsets","events","configmaps","services","chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["get","create","update","patch","delete","list","watch","deletecollection"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/docs/litmus-operator-latest.yaml
+++ b/docs/litmus-operator-latest.yaml
@@ -19,9 +19,9 @@ metadata:
   labels:
     name: litmus
 rules:
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
+- apiGroups: ["","apps","batch","litmuschaos.io"]
+  resources: ["pods","jobs","deployments","daemonsets","statefulsets","events","configmaps","services","chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["get","create","update","patch","delete","list","watch","deletecollection"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/docs/litmus-operator-namespaced-scope.yaml
+++ b/docs/litmus-operator-namespaced-scope.yaml
@@ -12,9 +12,9 @@ metadata:
   labels:
     name: litmus
 rules:
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
+- apiGroups: ["","apps","batch","litmuschaos.io"]
+  resources: ["pods","jobs","deployments","daemonsets","statefulsets","events","configmaps","services","chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["get","create","update","patch","delete","list","watch","deletecollection"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Adding minimal permissions for service account used by chaos-operator  deployment