### PR TITLE
(fix) add support for additional engine states

### DIFF
--- a/docs/litmus-operator-ci.yaml
+++ b/docs/litmus-operator-ci.yaml
@@ -133,7 +133,7 @@ spec:
               type: string
             engineState: 
               type: string
-              pattern: ^(active|stop)$
+              pattern: ^(active|stop|initialized|stopped)$
             chaosServiceAccount:
               type: string
             components:

--- a/docs/litmus-operator-latest.yaml
+++ b/docs/litmus-operator-latest.yaml
@@ -133,7 +133,7 @@ spec:
               type: string
             engineState: 
               type: string
-              pattern: ^(active|stop)$
+              pattern: ^(active|stop|initialized|stopped)$
             chaosServiceAccount:
               type: string
             components:

--- a/docs/litmus-operator-namespaced-scope.yaml
+++ b/docs/litmus-operator-namespaced-scope.yaml
@@ -124,7 +124,7 @@ spec:
               type: string
             engineState: 
               type: string
-              pattern: ^(active|stop)$
+              pattern: ^(active|stop|initialized|stopped)$
             chaosServiceAccount:
               type: string
             components:


### PR DESCRIPTION
- The controller patches the engineState with "initialized, stopped" to prevent undesirable reconcile once the respective action has been taken on the user options "active|stop"
- These states need to be added into the CRD validation schema, failing which - once the runner/monitor are created, the engine cannot be patched afterwards.

Signed-off-by: ksatchit <ksatchit@mayadata.io>