### PR TITLE
bug-fix(ChaosResult): Removing status from subresources in litmus operator latest

### DIFF
--- a/docs/litmus-operator-latest.yaml
+++ b/docs/litmus-operator-latest.yaml
@@ -340,8 +340,6 @@ spec:
     plural: chaosresults
     singular: chaosresult
   scope: Namespaced
-  subresources:
-    status: {}
   validation:
     openAPIV3Schema:
       properties:


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>

- Removing status from subresources in litmus operator latest