### PR TITLE
(chore)update patch image versions for v1.2.0 operator

### DIFF
--- a/docs/litmus-operator-v1.2.0.yaml
+++ b/docs/litmus-operator-v1.2.0.yaml
@@ -56,13 +56,13 @@ spec:
       serviceAccountName: litmus
       containers:
         - name: chaos-operator
-          image: litmuschaos/chaos-operator:1.2.0
+          image: litmuschaos/chaos-operator:1.2.2
           command:
           - chaos-operator
           imagePullPolicy: Always
           env:
             - name: CHAOS_RUNNER_IMAGE
-              value: "litmuschaos/chaos-runner:1.2.0"
+              value: "litmuschaos/chaos-runner:1.2.2"
             - name: CHAOS_MONITOR_IMAGE
               value: "litmuschaos/chaos-exporter:1.2.0"
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
- Update operator and runner images in v1.2.0 operator manifest to patch release 1.2.2

Signed-off-by: ksatchit <karthik.s@mayadata.io>